### PR TITLE
Fix bug: cannot send request without email & mobile, but you can send request only by email or only by mobile

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -34,16 +34,23 @@ class Request
     {
         $url = 'https://api.zarinpal.com/pg/v4/payment/request.json';
 
+        $metadata = [];
+        
+        if ($this->mobile) {
+            $metadata['mobile'] = $this->mobile;
+        }
+        
+        if ($this->email) {
+            $metadata['email'] = $this->email;
+        }
+
         $data = [
             'merchant_id' => $this->merchantId,
             'currency' => config('zarinpal.currency'),
             'amount' => $this->amount,
             'description' => $this->description,
             'callback_url' => $this->callbackUrl,
-            'metadata' => [
-                'mobile' => $this->mobile,
-                'email' => $this->email,
-            ],
+            'metadata' => $metadata,
         ];
 
         $response = Http::asJson()->acceptJson()->post($url, $data);


### PR DESCRIPTION
وقتی شماره موبایل یا ایمیل رو استرینگ خالی / null / undefined بذاریم، زرین پال خطای اعتبارسنجی میده. در نتیجه فقط در صورتی که ایمیل یا شماره موبایل پر شده بود باید داخل metadata قرارشون بدیم.